### PR TITLE
feat!: remove challengeContainerOptions, add containerId to startChallenge

### DIFF
--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -26,6 +26,7 @@ type ThreeDSChallengeRequest = {
    * @deprecated This property is deprecated and will be removed in the next major version
    */
   mode?: AcsMode;
+  containerId?: string;
 };
 interface AcsThreeDSChallengeRequest {
   messageType: 'CReq'; // Must always be set to "CReq"
@@ -64,9 +65,10 @@ function isAcsThreeDSChallengeRequest(
 const submitChallengeRequest = (
   acsURL: string,
   creq: AcsThreeDSChallengeRequest,
+  containerId?: string
 ) => {
   const container = document.getElementById(
-    CHALLENGE_REQUEST.FRAME_CONTAINER_ID
+    containerId ?? CHALLENGE_REQUEST.FRAME_CONTAINER_ID
   );
 
   const windowSize = getWindowSizeById(creq.challengeWindowSize);
@@ -146,6 +148,7 @@ const makeChallengeRequest = ({
   threeDSVersion,
   windowSize,
   mode,
+  containerId,
 }: ThreeDSChallengeRequest): Promise<ThreeDSSession | Error> => {
   if (!sessionId) {
     throw new Error('Session ID is required');
@@ -163,7 +166,7 @@ const makeChallengeRequest = ({
     if (mode === ACS_MODE.REDIRECT) {
       submitChallengeRequestRedirect(acsChallengeUrl, creq);
     } else {
-      submitChallengeRequest(acsChallengeUrl, creq);
+      submitChallengeRequest(acsChallengeUrl, creq, containerId);
     }
   } else {
     const err = `Invalid challenge request payload for session: ${sessionId}`;
@@ -184,6 +187,7 @@ export const startChallenge = async ({
   windowSize,
   mode = 'iframe',
   timeout = 60000,
+  containerId,
 }: ThreeDSChallengeRequest) => {
   await makeChallengeRequest({
     sessionId,
@@ -191,7 +195,8 @@ export const startChallenge = async ({
     acsChallengeUrl,
     threeDSVersion,
     windowSize,
-    mode
+    mode,
+    containerId
   }).catch((error) => {
     return Promise.reject((error as Error).message);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,6 @@ type ConfigOptions = {
    * Disables telemetry
    */
   disableTelemetry?: boolean;
-  challengeContainerOptions?: {
-    /**
-     * Overrides default ID of iframe container
-     */
-    id?: string;
-  };
 };
 
 const BasisTheory3ds = (() => {
@@ -45,10 +39,7 @@ const BasisTheory3ds = (() => {
         disableTelemetry: configOptions?.disableTelemetry ?? false,
       });
       createIframeContainer(METHOD_REQUEST.FRAME_CONTAINER_ID, true);
-      createIframeContainer(
-        configOptions?.challengeContainerOptions?.id ??
-          CHALLENGE_REQUEST.FRAME_CONTAINER_ID
-      );
+      createIframeContainer(CHALLENGE_REQUEST.FRAME_CONTAINER_ID);
     } catch (error) {
       logger.log.error('Unable to create iframe container', error as Error);
     }


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Add containerId to startChallenge - the challenge iframe will be appended to that container.
- BREAKING CHANGE ⚠️ : Remove `challengeContainerOptions` - not being used in the code.

## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

<!-- Ensure that all related documentation on notion is updated -->
## Documentation


## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change