### PR TITLE
fix: ignore external events on create session instead of reject

### DIFF
--- a/tests/handleCreateSession.test.ts
+++ b/tests/handleCreateSession.test.ts
@@ -56,8 +56,5 @@ test.each([
 
     await expect(promise).resolves.toEqual(expectedResponse);
     expect(removeIframe).toHaveBeenCalledWith([iframeContainerId]);
-    expect(logger.log.info).toHaveBeenCalledWith(
-      `${notificationType} notification received for session: ${expectedResponse.id}`
-    );
   }
 );


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Ignore unknown events on create session message handler instead of rejecting the promise

## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

<!-- Ensure that all related documentation on notion is updated -->
## Documentation


## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change