### PR TITLE
feat: return challenge status, fix errors

### DIFF
--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -5,7 +5,6 @@ import { WindowSizeId, getWindowSizeById } from './utils/browser';
 import { createForm, createIframe, createInput } from './utils/dom';
 import { encode } from './utils/encoding';
 import { logger } from './utils/logging';
-import { NotificationType, notify } from '~src/utils/events';
 
 type ThreeDSChallengeRequest = {
   acsChallengeUrl: string;
@@ -110,8 +109,7 @@ const submitChallengeRequestRedirect = (
   );
 
   if (!newWindow) {
-    console.error('Popup blocked or unable to open the window.');
-    return;
+    throw new Error('Popup blocked or unable to open the window.');
   }
 
   const creqBase64 = encode(creq);
@@ -127,18 +125,6 @@ const submitChallengeRequestRedirect = (
 
   document.body.appendChild(form);
   form.submit();
-
-  // check periodically if method window is closed (it closes immediatelly on completion)
-  const checkClosedInterval = window.setInterval(() => {
-    if (newWindow.closed) {
-      clearInterval(checkClosedInterval);
-      notify({
-        isCompleted: true,
-        id: creq.threeDSServerTransID,
-        type: NotificationType.CHALLENGE,
-      });
-    }
-  }, 500);
 };
 
 const makeChallengeRequest = ({

--- a/src/handlers/handleCreateSession.ts
+++ b/src/handlers/handleCreateSession.ts
@@ -29,7 +29,7 @@ export const handleCreateSession = (
         if (event.data.type === NotificationType.ERROR) {
           logger.log.error(`Error occurred during session creation: ${event?.data?.details}`);
 
-          reject(`An error occurred during session creation: ${event?.data?.details}`);
+          reject(new Error(`An error occurred during session creation: ${event?.data?.details}`));
           removeIframe(getIframeId(event.data?.type));
           clearTimeout(timeout);
         } else if (event.data.type === NotificationType.START_METHOD_TIME_OUT) {

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -14,6 +14,8 @@ export type Notification = {
   type: NotificationType;
   // additional event info (detailed errors)
   details?: string;
+  // for challenge notifications
+  authenticationStatus?: string;
 };
 
 export const notify = (notification: Notification) =>

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -16,8 +16,6 @@ export type Notification = {
   details?: string;
   // for challenge notifications
   authenticationStatus?: string;
-  // reason for the authentication status
-  authenticationStatusReason?: string;
 };
 
 export const notify = (notification: Notification) =>

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -16,6 +16,8 @@ export type Notification = {
   details?: string;
   // for challenge notifications
   authenticationStatus?: string;
+  // reason for the authentication status
+  authenticationStatusReason?: string;
 };
 
 export const notify = (notification: Notification) =>

--- a/tests/challenge.test.ts
+++ b/tests/challenge.test.ts
@@ -69,6 +69,8 @@ describe('startChallenge', () => {
 
     const startChallengeResponse = {
       id: sessionId,
+      isCompleted: true,
+      authenticationStatus: 'successful',
     };
 
     const response = startChallenge({
@@ -83,7 +85,7 @@ describe('startChallenge', () => {
 
     window.dispatchEvent(
       new MessageEvent('message', {
-        data: { isCompleted: true, id: sessionId, type: 'challenge' },
+        data: { isCompleted: true, id: sessionId, type: 'challenge', authenticationStatus: 'successful' },
       })
     );
 
@@ -111,8 +113,8 @@ describe('startChallenge', () => {
 
     await resolvePendingPromises();
 
-    expect(response).rejects.toEqual(
-      'Timed out waiting for a challenge response. Please try again.'
+    expect(response).rejects.toThrow(
+      new Error('Timed out waiting for a challenge response. Please try again.')
     );
   }, 10001);
 
@@ -144,6 +146,7 @@ describe('startChallenge', () => {
 
     const startChallengeResponse = {
       id: sessionId,
+      isCompleted: true,
     };
 
     queueMock(startChallengeResponse);

--- a/tests/handleChallenge.test.ts
+++ b/tests/handleChallenge.test.ts
@@ -25,7 +25,7 @@ test.each([
     `should resolve with response when receiving valid ${NotificationType.CHALLENGE} notification`,
     NotificationType.CHALLENGE,
     CHALLENGE_REQUEST.IFRAME_NAME,
-    { id: '1234' },
+    { id: '1234', isCompleted: true, authenticationStatus: 'successful' },
   ],
 ])(
   '%s',
@@ -41,6 +41,7 @@ test.each([
       isCompleted: true,
       type: notificationType,
       id: '1234',
+      authenticationStatus: 'successful',
     };
 
     // Dispatch the message


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Return `isCompleted` and `authentication_status` in the `startChallenge` response
- Fix so some rejects throw an `Error` instead of just a string for better debugging
- Throw `Error` if error is received from challenge notification
- Listen to actual parent message/notification instead of polling for window closure on challenge `redirect` flow 

## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

<!-- Ensure that all related documentation on notion is updated -->
## Documentation


## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change