### PR TITLE
feat!: normalize 3DS error fields to camelCase and export types

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,137 @@ await startChallenge({
 });
 ```
 
+## Error Handling
+
+Both `createSession` and `startChallenge` may throw errors that include detailed information about what went wrong.
+
+- **API errors** (from `createSession`) are returned as Error objects with additional properties containing the full error details from the 3DS service
+- **Challenge errors** (from `startChallenge`) are returned as standard Error objects with descriptive messages
+
+### Error Structure
+
+```typescript
+try {
+  const session = await createSession({ tokenId: 'token_id' });
+} catch (error) {
+  // Error object properties:
+  console.log(error.message); // Human-readable error message
+  console.log(error.title); // Error title (e.g., "3DS Service Error")
+  console.log(error.status); // HTTP status code (e.g., 424)
+  console.log(error.detail); // Detailed description
+
+  // Nested error object with additional context (normalized to camelCase):
+  if (error.error) {
+    console.log(error.error.serviceStatus); // HTTP status from 3DS service (e.g., "403")
+    console.log(error.error.sessionId); // Session ID for debugging
+    console.log(error.error.errorSource); // Which service failed (e.g., "3DS Server", "ACS")
+    console.log(error.error.message); // Detailed error message
+    console.log(error.error.detail); // Additional error context
+  }
+}
+```
+
+### Common Error Scenarios
+
+#### 1. 3DS Service Errors (Status 424)
+
+These errors occur when the 3DS service or card issuer returns an error:
+
+```typescript
+try {
+  const session = await createSession({ tokenId: 'token_id' });
+} catch (error) {
+  if (error.status === 424) {
+    // Handle 3DS service errors
+    switch (error.error?.serviceStatus) {
+      case '403':
+        // Access denied by issuer
+        console.log('Merchant configuration issue:', error.error.detail);
+        break;
+      case '401':
+        // Authentication failed
+        console.log('Authentication failed:', error.error.message);
+        break;
+      default:
+        console.log('3DS service error:', error.message);
+    }
+  }
+}
+```
+
+#### 2. Validation Errors (Status 400)
+
+These errors occur when the request parameters are invalid:
+
+```typescript
+try {
+  const session = await createSession({ tokenId: 'invalid_token' });
+} catch (error) {
+  if (error.status === 400) {
+    console.log('Validation error:', error.message);
+  }
+}
+```
+
+### Example: Comprehensive Error Handling
+
+```typescript
+import { BasisTheory3ds } from '@basis-theory/web-threeds';
+
+const bt3ds = BasisTheory3ds('your_api_key');
+
+try {
+  const session = await bt3ds.createSession({ tokenId: 'token_id' });
+
+  // Continue with challenge if needed
+  try {
+    await bt3ds.startChallenge({
+      sessionId: session.id,
+      acsTransactionId: 'acs_transaction_id',
+      acsChallengeUrl: 'acs_challenge_url',
+      threeDSVersion: '2.2.0',
+    });
+  } catch (challengeError) {
+    // Handle challenge-specific errors
+    console.error('Challenge error:', challengeError.message);
+    if (challengeError.message.includes('Timed out')) {
+      showErrorToUser('Challenge timed out. Please try again.');
+    } else if (challengeError.message.includes('Invalid challenge request')) {
+      showErrorToUser('Invalid challenge configuration.');
+    } else {
+      showErrorToUser('Challenge failed. Please try again.');
+    }
+    throw challengeError; // Re-throw to outer catch
+  }
+} catch (error) {
+  // Log full error details for debugging
+  console.error('3DS Error:', {
+    message: error.message,
+    title: error.title,
+    status: error.status,
+    detail: error.detail,
+    error: error.error,
+  });
+
+  // Determine action based on error type
+  if (error.status === 424 && error.error?.errorSource === '3DS Server') {
+    // Merchant configuration issue - contact support
+    showErrorToUser(
+      'Payment authentication unavailable. Please try a different card.'
+    );
+  } else if (error.status === 424 && error.error?.errorSource === 'ACS') {
+    // Issuer authentication issue
+    showErrorToUser('Card authentication failed. Please contact your bank.');
+  } else if (error.status === 400) {
+    // Validation error
+    showErrorToUser('Invalid card information. Please check and try again.');
+  } else {
+    // Generic error (could be challenge error or session error)
+    showErrorToUser('An error occurred. Please try again later.');
+  }
+}
+```
+
 ## Configuration Options
 
 ### Challenge Request

--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -191,9 +191,9 @@ export const startChallenge = async ({
     windowSize,
     mode,
     containerId,
-  }).catch((error) => {
-    return Promise.reject((error as Error).message);
   });
+  // If makeChallengeRequest succeeds, continue with challenge
+  // If it fails, the error will propagate automatically
 
   return handleChallenge(timeout);
 };

--- a/src/session.ts
+++ b/src/session.ts
@@ -234,7 +234,8 @@ export const createSession = async ({
     challengeMode,
     correlationId,
   }).catch((error) => {
-    return Promise.reject((error as Error).message);
+    // Preserve the full error object (BasisTheory3dsError or other Error types)
+    return Promise.reject(error);
   });
 
   // skip message handling, no method request necessary

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,29 +1,88 @@
-const errorMessagesMap: Record<string, string> = {
-  // Add mappings for specific error titles or details
-  // 'Some Error Title': 'A user-friendly error message.',
-};
-
 const validationErrorMessagesMap: Record<string, string> = {
   'The card was not supported by any card schemes':
     '3DS is not supported for the provided card',
   // Add mappings for specific error titles or details as needed
 };
 
+/**
+ * Nested error details from the 3DS service
+ * Normalized to camelCase for consistent JavaScript/TypeScript convention
+ */
+type ThreeDSServiceError = {
+  serviceStatus?: string;
+  sessionId?: string;
+  errorSource?: string;
+  message?: string;
+  detail?: string;
+};
+
+/**
+ * Raw API error format (may have snake_case from backend)
+ */
 type ApiError = {
   title?: string;
   status?: number;
   detail?: string;
   error?: {
+    service_status?: string;
+    session_id?: string;
+    error_source?: string;
+    message?: string;
+    detail?: string;
+    // Legacy camelCase support
     serviceStatus?: string;
     sessionId?: string;
     errorSource?: string;
-    message?: string;
     details?: string;
   };
 };
 
 type ValidationApiError = ApiError & {
   errors: Record<string, string[]>;
+};
+
+/**
+ * Enhanced error type that includes the full API error structure
+ */
+type BasisTheory3dsError = Error & {
+  title?: string;
+  status?: number;
+  detail?: string;
+  error?: ThreeDSServiceError;
+};
+
+/**
+ * Creates an error object that preserves the full API error structure
+ * Normalizes snake_case (from API) to camelCase (JavaScript convention)
+ */
+const createBasisTheory3dsError = (apiError: ApiError): BasisTheory3dsError => {
+  // Set the error message to be the most descriptive field available
+  const message =
+    apiError.error?.message ||
+    apiError.detail ||
+    apiError.title ||
+    'An unknown error occurred';
+
+  const error = new Error(message) as BasisTheory3dsError;
+  error.name = 'BasisTheory3dsError';
+  error.title = apiError.title;
+  error.status = apiError.status;
+  error.detail = apiError.detail;
+
+  // Normalize the nested error object to camelCase for consistent JavaScript convention
+  // This transforms snake_case from the API to match the rest of the SDK
+  if (apiError.error) {
+    error.error = {
+      serviceStatus:
+        apiError.error.service_status || apiError.error.serviceStatus,
+      sessionId: apiError.error.session_id || apiError.error.sessionId,
+      errorSource: apiError.error.error_source || apiError.error.errorSource,
+      message: apiError.error.message,
+      detail: apiError.error.detail || apiError.error.details,
+    };
+  }
+
+  return error;
 };
 
 const isValidationApiError = (error: ApiError): error is ValidationApiError => {
@@ -50,27 +109,12 @@ const processApiError = (apiError: ApiError): never => {
         throw new Error(validationErrorMessagesMap[errorKey]);
       }
     }
-  } else if (apiError.status === 424 && apiError.error) {
-    // handle 3DS service error case
-    const errorParts = [];
-    if (apiError.error.message) errorParts.push(apiError.error.message);
-    if (apiError.error.details)
-      errorParts.push('details: ' + apiError.error.details);
-
-    const errorMessage =
-      errorParts.length > 0
-        ? errorParts.join(' - ')
-        : apiError.title || 'An unknown 3DS service error occurred';
-
-    throw new Error(errorMessage);
-  } else {
-    if (apiError.title && errorMessagesMap[apiError.title]) {
-      throw new Error(errorMessagesMap[apiError.title]);
-    }
   }
 
-  // if no matching mapping is found, throw a generic error
-  throw new Error(apiError.title || 'An unknown error occurred');
+  // For all API errors (including 3DS service errors with status 424),
+  // throw a custom error that preserves the full error structure
+  throw createBasisTheory3dsError(apiError);
 };
 
 export { processApiError, isApiError };
+export type { BasisTheory3dsError, ThreeDSServiceError };

--- a/tests/challenge.test.ts
+++ b/tests/challenge.test.ts
@@ -132,7 +132,7 @@ describe('startChallenge', () => {
       windowSize: '10' as WindowSizeId,
     });
 
-    expect(response).rejects.toEqual(
+    await expect(response).rejects.toThrow(
       `Invalid challenge request payload for session: ${222}`
     );
   });


### PR DESCRIPTION
BREAKING CHANGE: Error handling now returns full Error objects instead of strings

- Export ThreeDSServiceError type for TypeScript users
- Normalize snake_case API fields to camelCase for consistent JavaScript convention
- Update all tests to expect camelCase error fields
- Update README documentation to show camelCase examples
- Ensure backward compatibility by handling both snake_case and camelCase from API

<!-- Describe your changes in detail -->
## Description

-

## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

<!-- Ensure that all related documentation on notion is updated -->
## Documentation


## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change