### PR TITLE
chore(ENG-10883): migrate to shared terraform action

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,42 +12,18 @@ jobs:
       contents: read
     environment: DEV
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Configure AWS Actions Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/github-actions-admin-dev
-          aws-region: us-east-2
-
-      - name: Configure AWS Terraform Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.6
-
-      - name: Terraform Init
-        id: init
-        run: terraform init -backend-config=dev.tfbackend
-        working-directory: terraform/
-        continue-on-error: false
-
       - name: Terraform Apply Dev
-        id: plan
-        run: terraform apply -auto-approve
-        working-directory: terraform/
-        continue-on-error: false
+        uses: Basis-Theory/github-actions/terraform-action@master
+        with:
+          tf-directory: terraform
+          operation: apply
+          environment: dev
+          region: us-east-2
         env:
+          TF_CLI_ARGS_init: -backend-config=dev.tfbackend
           TF_VAR_env: dev
-          TF_VAR_r2_access_key: ${{secrets.R2_ACCESS_KEY}}
-          TF_VAR_r2_secret_key: ${{secrets.R2_SECRET_KEY}}
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
 
   build-release:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,15 +12,29 @@ jobs:
       contents: read
     environment: DEV
     steps:
-      - name: Terraform Apply Dev
-        uses: Basis-Theory/github-actions/terraform-action@master
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          tf-directory: terraform
-          operation: apply
-          environment: dev
-          region: us-east-2
+          role-to-assume: arn:aws:iam::914054469264:role/web-threeds-gh-admin
+          aws-region: us-east-2
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: terraform init -backend-config=dev.tfbackend
+        working-directory: terraform/
         env:
-          TF_CLI_ARGS_init: -backend-config=dev.tfbackend
+          TF_VAR_env: dev
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
+
+      - name: Terraform Apply Dev
+        run: terraform apply -auto-approve
+        working-directory: terraform/
+        env:
           TF_VAR_env: dev
           TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
           TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,17 +72,48 @@ jobs:
       fail-fast: true
       matrix:
         env: [dev, prod]
+        include:
+          - env: dev
+            account_id: "914054469264"
+          - env: prod
+            account_id: "469828239459"
 
     steps:
-      - name: Terraform Plan
-        uses: Basis-Theory/github-actions/terraform-action@master
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          tf-directory: terraform
-          operation: plan
-          environment: ${{ matrix.env }}
-          region: us-east-2
+          role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/web-threeds-gh-ro
+          aws-region: us-east-2
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: terraform init -backend-config=${{ matrix.env }}.tfbackend
+        working-directory: terraform/
         env:
-          TF_CLI_ARGS_init: -backend-config=${{ matrix.env }}.tfbackend
+          TF_VAR_env: ${{ matrix.env }}
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
+
+      - name: Terraform fmt
+        run: terraform fmt -check -diff
+        working-directory: terraform/
+
+      - name: Terraform validate
+        run: terraform validate
+        working-directory: terraform/
+        env:
+          TF_VAR_env: ${{ matrix.env }}
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
+
+      - name: Terraform plan
+        run: terraform plan
+        working-directory: terraform/
+        env:
           TF_VAR_env: ${{ matrix.env }}
           TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
           TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,64 +62,8 @@ jobs:
         env:
           SKIP_INSTALL: 1 # install with cache was done already
 
-  terraform-format-validate:
-    runs-on: ubuntu-latest
-
-    environment: PR
-
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/github-actions-admin-dev
-          aws-region: us-east-2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
-
-      - name: Terraform fmt
-        id: fmt
-        run: terraform fmt -check -diff
-        working-directory: terraform/
-        continue-on-error: false
-
-      - name: Terraform init
-        id: init
-        run: terraform init -backend-config=dev.tfbackend
-        working-directory: terraform/
-        continue-on-error: false
-        env:
-          TF_VAR_env: dev
-          TF_VAR_r2_access_key: ${{secrets.R2_ACCESS_KEY}}
-          TF_VAR_r2_secret_key: ${{secrets.R2_SECRET_KEY}}
-
-      - name: Terraform validate
-        id: validate
-        run: terraform validate
-        working-directory: terraform/
-        continue-on-error: false
-        env:
-          TF_VAR_env: dev
-          TF_VAR_r2_access_key: ${{secrets.R2_ACCESS_KEY}}
-          TF_VAR_r2_secret_key: ${{secrets.R2_SECRET_KEY}}
-
   terraform-plan:
     runs-on: ubuntu-latest
-    needs:
-      - terraform-format-validate
     permissions:
       id-token: write
       contents: read
@@ -128,43 +72,17 @@ jobs:
       fail-fast: true
       matrix:
         env: [dev, prod]
-        include:
-          - env: dev
-            account_id: "914054469264"
-          - env: prod
-            account_id: "469828239459"
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - name: Terraform Plan
+        uses: Basis-Theory/github-actions/terraform-action@master
         with:
-          terraform_wrapper: false
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::${{matrix.account_id}}:role/github-actions-admin-${{matrix.env}}
-          aws-region: us-east-2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::${{matrix.account_id}}:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
-
-      - name: Terraform init
-        id: init
-        run: terraform init -backend-config=${{matrix.env}}.tfbackend
-        working-directory: terraform/
-        continue-on-error: false
-
-      - name: Terraform plan dev
-        id: plan
-        run: terraform plan
-        working-directory: terraform/
-        continue-on-error: false
+          tf-directory: terraform
+          operation: plan
+          environment: ${{ matrix.env }}
+          region: us-east-2
         env:
-          TF_VAR_env: ${{matrix.env}}
-          TF_VAR_r2_access_key: ${{secrets.R2_ACCESS_KEY}}
-          TF_VAR_r2_secret_key: ${{secrets.R2_SECRET_KEY}}
+          TF_CLI_ARGS_init: -backend-config=${{ matrix.env }}.tfbackend
+          TF_VAR_env: ${{ matrix.env }}
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,46 +12,18 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
-
-      - name: Configure AWS Actions Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::469828239459:role/github-actions-admin-prod
-          aws-region: us-east-2
-
-      - name: Configure AWS Terraform Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::469828239459:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.6
-
-      - name: Terraform Init
-        id: init
-        run: terraform init -backend-config=prod.tfbackend
-        working-directory: terraform/
-        continue-on-error: false
-
       - name: Terraform Apply Prod
-        id: plan
-        run: terraform apply -auto-approve
-        working-directory: terraform/
-        continue-on-error: false
+        uses: Basis-Theory/github-actions/terraform-action@master
+        with:
+          tf-directory: terraform
+          operation: apply
+          environment: prod
+          region: us-east-2
         env:
+          TF_CLI_ARGS_init: -backend-config=prod.tfbackend
           TF_VAR_env: prod
-          TF_VAR_r2_access_key: ${{secrets.R2_ACCESS_KEY}}
-          TF_VAR_r2_secret_key: ${{secrets.R2_SECRET_KEY}}
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
 
   build-release:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,29 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Terraform Apply Prod
-        uses: Basis-Theory/github-actions/terraform-action@master
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          tf-directory: terraform
-          operation: apply
-          environment: prod
-          region: us-east-2
+          role-to-assume: arn:aws:iam::469828239459:role/web-threeds-gh-admin
+          aws-region: us-east-2
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: terraform init -backend-config=prod.tfbackend
+        working-directory: terraform/
         env:
-          TF_CLI_ARGS_init: -backend-config=prod.tfbackend
+          TF_VAR_env: prod
+          TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
+          TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
+
+      - name: Terraform Apply Prod
+        run: terraform apply -auto-approve
+        working-directory: terraform/
+        env:
           TF_VAR_env: prod
           TF_VAR_r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
           TF_VAR_r2_secret_key: ${{ secrets.R2_SECRET_KEY }}


### PR DESCRIPTION
## Summary

- Replaces inline `hashicorp/setup-terraform` + `aws-actions/configure-aws-credentials` + terraform commands across all three deploy workflows with `Basis-Theory/github-actions/terraform-action@master`
- `deploy-dev.yml`: single `terraform-action` step for dev apply; backend config passed via `TF_CLI_ARGS_init`
- `pull-request.yml`: collapses `terraform-format-validate` + `terraform-plan` jobs into a single `terraform-plan` job with a `[dev, prod]` matrix; account IDs derived automatically by the action from `environment` input
- `release.yml`: single `terraform-action` step for prod apply; backend config passed via `TF_CLI_ARGS_init`
- IAM roles (`web-threeds-gh-ro` / `web-threeds-gh-admin`) are already provisioned in `tf-aws-global` for `dev` and `prod` accounts

## Test plan

- [ ] Raise a PR against master and confirm both matrix legs (`dev`, `prod`) plan successfully
- [ ] Merge to master and confirm dev apply succeeds in the `DEV` environment
- [ ] Publish a release and confirm prod apply succeeds in the `PROD` environment

Closes part of ENG-10883

🤖 Generated with [Claude Code](https://claude.com/claude-code)