### PR TITLE
fix(ENG-11188): replace terraform-admin role chain with scoped IAM roles

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -63,18 +63,11 @@ jobs:
 
       - uses: AnimMouse/setup-rclone@v1
 
-      - name: Configure AWS Actions Credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::914054469264:role/github-actions-admin-dev
+          role-to-assume: arn:aws:iam::914054469264:role/web-threeds-gh-admin
           aws-region: us-east-2
-
-      - name: Configure AWS Terraform Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,18 +25,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Configure AWS Actions Credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::914054469264:role/github-actions-admin-dev
+          role-to-assume: arn:aws:iam::914054469264:role/web-threeds-gh-admin
           aws-region: us-east-2
-
-      - name: Configure AWS Terraform Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write
       contents: read
       actions: read
     strategy:
@@ -24,12 +23,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/web-threeds-gh-admin
-          aws-region: us-east-2
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,18 +63,11 @@ jobs:
 
       - uses: AnimMouse/setup-rclone@v1
 
-      - name: Configure AWS Actions Credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::469828239459:role/github-actions-admin-prod
+          role-to-assume: arn:aws:iam::469828239459:role/web-threeds-gh-admin
           aws-region: us-east-2
-
-      - name: Configure AWS Terraform Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::469828239459:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
 
       - name: Start Deploy Message
         uses: Basis-Theory/public-github-actions/deploy-slack-action@master


### PR DESCRIPTION
## Description

- `deploy-dev.yml`: replace 2-hop chain (`github-actions-admin-dev` → `terraform-admin`) with `web-threeds-gh-admin` (dev account 914054469264)
- `pull-request.yml`: replace 2-hop chain → `web-threeds-gh-admin` (dev account 914054469264); runs on every PR
- `release.yml`: replace 2-hop chain (`github-actions-admin-prod` → `terraform-admin`) with `web-threeds-gh-admin` (prod account 469828239459); covers terraform apply + CDN bundle deploy
- Part of ENG-11174 — migrating all repos off `terraform-admin` role chaining to per-repo scoped IAM roles

## Business Impact

- Minimal

## Testing required outside of automated testing?

- [x] Not Applicable

### Screenshots (if appropriate):

- [x] Not Applicable

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Documentation


## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change