### PR TITLE
chore(ENG-11425): replace semantic-release PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -58,8 +58,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
 
       - uses: AnimMouse/setup-rclone@v1
 
@@ -101,12 +99,12 @@ jobs:
           BLOB: true
           CLOUDFLARE: true
           ENVIRONMENT: dev # Used by uploadbundle.sh for R2 bucket naming (dev-3ds)
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
           R2_ACCESS_KEY: ${{secrets.R2_ACCESS_KEY}}
           R2_SECRET_KEY: ${{secrets.R2_SECRET_KEY}}
 
   create-pre-release:
     runs-on: ubuntu-latest
+    environment: TAG
     needs:
       - build-release
       - terraform-dev
@@ -114,11 +112,18 @@ jobs:
       matrix:
         node: ["20.x"]
     steps:
+      - name: Mint tag-app token
+        id: tag-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_TAG_APP_ID }}
+          private-key: ${{ secrets.GH_APP_TAG_KEY }}
+
       - name: Version and Tag
         id: version-and-tag
         uses: mathieudutour/github-tag-action@v5.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.tag-token.outputs.token }}
 
       - name: Generate Release Notes
         id: release-notes

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,14 +12,14 @@ jobs:
       contents: read
     environment: DEV
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::914054469264:role/web-threeds-gh-admin
           aws-region: us-east-2
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_wrapper: false
 
@@ -57,30 +57,30 @@ jobs:
       - terraform-dev
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: AnimMouse/setup-rclone@v1
+      - uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
           role-to-assume: arn:aws:iam::914054469264:role/web-threeds-gh-admin
           aws-region: us-east-2
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           # registry-url not needed - no npm publishing in dev workflow
 
       - name: Install Deps (with cache)
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
         with:
           install-command: yarn --immutable --no-progress --ignore-scripts
 
       - name: Get New Version
         id: get-new-version
-        uses: mathieudutour/github-tag-action@v5.2
+        uses: mathieudutour/github-tag-action@a2505118dd9b4797d9f8d45747f562db67e2aa6c # v5.2
         with:
           dry_run: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,20 +114,20 @@ jobs:
     steps:
       - name: Mint tag-app token
         id: tag-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.GH_TAG_APP_ID }}
           private-key: ${{ secrets.GH_APP_TAG_KEY }}
 
       - name: Version and Tag
         id: version-and-tag
-        uses: mathieudutour/github-tag-action@v5.2
+        uses: mathieudutour/github-tag-action@a2505118dd9b4797d9f8d45747f562db67e2aa6c # v5.2
         with:
           github_token: ${{ steps.tag-token.outputs.token }}
 
       - name: Generate Release Notes
         id: release-notes
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         env:
           NEW_RELEASE_TAG: ${{ steps.version-and-tag.outputs.new_tag }}
         with:
@@ -147,7 +147,7 @@ jobs:
             return releaseNotes.data.body;
 
       - name: Create Pre-Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           prerelease: true
           generate_release_notes: false
@@ -158,7 +158,7 @@ jobs:
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_DEV_DEPLOY_CHANNEL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::469828239459:role/web-threeds-gh-admin
           aws-region: us-east-2
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_wrapper: false
 
@@ -58,32 +58,32 @@ jobs:
     steps:
       - name: Mint semantic-release app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: AnimMouse/setup-rclone@v1
+      - uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
           role-to-assume: arn:aws:iam::469828239459:role/web-threeds-gh-admin
           aws-region: us-east-2
 
       - name: Start Deploy Message
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           # registry-url is intentionally NOT set - it creates .npmrc that blocks OIDC
@@ -92,7 +92,7 @@ jobs:
         run: npm install -g npm@latest # Requires npm 11.5.1+ for OIDC support
 
       - name: Install Deps (with cache)
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
         with:
           install-command: yarn --immutable --no-progress --ignore-scripts
 
@@ -131,11 +131,11 @@ jobs:
     needs: build-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,17 @@ jobs:
     needs:
       - terraform-prod
     steps:
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: AnimMouse/setup-rclone@v1
 
@@ -107,7 +114,6 @@ jobs:
         env:
           CLOUDFLARE: true
           ENVIRONMENT: prod # Used by uploadbundle.sh for R2 bucket naming (prod-3ds)
-          GITHUB_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
           R2_ACCESS_KEY: ${{secrets.R2_ACCESS_KEY}}
           R2_SECRET_KEY: ${{secrets.R2_SECRET_KEY}}
 


### PR DESCRIPTION
## Description
- `deploy-dev.yml` — cut the tag/pre-release with the **bt-version-tagger** app: mint a token via `actions/create-github-app-token` (`vars.GH_TAG_APP_ID` + `secrets.GH_APP_TAG_KEY`) in the `TAG` environment (master-restricted) and pass it to `github-tag-action` + `softprops`. Drop the PAT from checkout; delete the dead `SEMANTIC_RELEASE_PAT` upload-bundle env var.
- `release.yml` — mint a **bt_semantic_release** token (`vars.SEMANTIC_RELEASE_APP_ID` + the `prod`-env `secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY`) and use it for checkout + the `git push origin HEAD:master` write-back. Delete the dead upload-bundle env var. npm OIDC publish stays on the native token.
- Removes all `GH_SEMANTIC_RELEASE_PAT` / `SEMANTIC_RELEASE_PAT` usage. Public repo, so no private composite action is referenced (inlined `create-github-app-token`).

> Merge order: requires github-repository-management#441 (prod write-back key) applied first. bt-version-tagger TAG env key already provisioned for this repo.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
ENG-11425

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change